### PR TITLE
Add cog documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Here are some of the cogs available in this repository:
 - **Dictionary**: Provides dictionary and thesaurus functionalities, allowing users to look up word definitions, synonyms, and antonyms.
 - **Giveaways**: Manage and run giveaways on your Discord server. Features include customizable giveaway duration, participant requirements, and automatic winner selection.
 
+## Documentation
+
+Learn more about each cog in their respective guides:
+
+- [MovieDB](./moviedb/README.md)
+- [Tierlists](./tierlists/README.md)
+- [Dictionary](./dictionary/README.rst)
+- [Giveaways](./giveaways/README.md)
+
 ## Contact
 
 If you encounter any issues, bugs, or have suggestions for improvements, feel free to reach out:

--- a/giveaways/README.md
+++ b/giveaways/README.md
@@ -1,0 +1,53 @@
+# Giveaways
+
+This is the cog guide for the 'Giveaways' cog. This guide contains the collection of commands which you can use in the cog. Throughout this guide, `[p]` will always represent your prefix. Replace `[p]` with your own prefix when you use these commands in Discord.
+
+> **Note:**
+> Ensure that you are up to date by running `[p]cog update giveaways`.
+> If there is something missing, or something that needs improving in this documentation, feel free to create an issue [here](https://github.com/90sCraig/Craigbot-Cogs/issues).
+> This documentation is auto-generated every time this cog receives an update.
+
+## About this cog
+
+Manage giveaways in your Discord server. Features include adjustable duration, automatic winner selection, multipliers, role restrictions, and more. Great for community events and prize drawings.
+
+## Commands
+
+### `giveaway start`
+Start a giveaway in the current channel. You can specify a duration and prize, for example:
+
+```
+[p]giveaway start 1h Awesome Prize
+```
+
+### `giveaway reroll`
+Pick a new winner for a finished giveaway.
+
+```
+[p]giveaway reroll <message_id>
+```
+
+### `giveaway end`
+End a running giveaway early.
+
+```
+[p]giveaway end <message_id>
+```
+
+### `giveaway advanced`
+Create a giveaway with advanced settings like custom emoji, images, or multiple winners.
+
+```
+[p]giveaway advanced prize="Big Prize" duration=1d winners=3
+```
+
+## Installation
+
+If you haven't added this repository before, run the following commands:
+
+```bash
+[p]repo add Craigbot-cogs https://github.com/90sCraig/Craigbot-Cogs
+[p]cog install Craigbot-cogs giveaways
+[p]load giveaways
+```
+

--- a/moviedb/README.md
+++ b/moviedb/README.md
@@ -1,0 +1,66 @@
+# MovieDB
+
+This is the cog guide for the 'MovieDB' cog. This guide contains the collection of commands which you can use in the cog. Throughout this guide, `[p]` will always represent your prefix. Replace `[p]` with your own prefix when you use these commands in Discord.
+
+> **Note:**
+> Ensure that you are up to date by running `[p]cog update moviedb`.
+> If there is something missing, or something that needs improving in this documentation, feel free to create an issue [here](https://github.com/90sCraig/Craigbot-Cogs/issues).
+> This documentation is auto-generated every time this cog receives an update.
+
+## About this cog
+
+Fetch information from [The Movie Database](https://www.themoviedb.org/). Look up movies, TV shows and celebrities, or get recommendations for what to watch next.
+
+## Commands
+
+### `celebrity`
+Show details about an actor, director or other movie personality.
+
+```
+[p]celebrity Tom Hanks
+```
+
+### `movie`
+Display information about a specific movie.
+
+```
+[p]movie The Matrix
+```
+
+### `tvshow`
+Display information about a TV series.
+
+```
+[p]tvshow Breaking Bad
+```
+
+### `suggestmovies`
+Get a list of recommended movies similar to the one provided.
+
+```
+[p]suggestmovies "Back to the Future"
+```
+
+### `suggestshows`
+Get a list of recommended TV shows similar to the one provided.
+
+```
+[p]suggestshows "Game of Thrones"
+```
+
+## Installation
+
+Before using this cog you will need a free API key from themoviedb.org. Once you have the key, set it up with:
+
+```
+[p]set api tmdb api_key <api_key>
+```
+
+If you haven't added this repository before, install with the following commands:
+
+```bash
+[p]repo add Craigbot-cogs https://github.com/90sCraig/Craigbot-Cogs
+[p]cog install Craigbot-cogs moviedb
+[p]load moviedb
+```
+


### PR DESCRIPTION
## Summary
- document each cog
- add a Documentation section linking to new guides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843a023cd50832cb10487314c8297cd