### PR TITLE
Fix README links in credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ If you encounter any issues, bugs, or have suggestions for improvements, feel fr
 
 This repository wouldn't be possible without the work of the original authors. Special thanks to:
 
-- [owocado](https://github.com/owocado) for the original [MovieDB cog](https://github.com/owocado/MovieDB-cog).
-- [i-am-zaidali](https://github.com/i-am-zaidali) for the original [Tierlists cog](https://github.com/i-am-zaidali/bounty-cogs/tree/main).
+- [owocado](https://github.com/owocado) for the original [MovieDB cog](https://github.com/owocado/cogs).
+- [i-am-zaidali](https://github.com/i-am-zaidali) for the original [Tierlists cog](https://github.com/i-am-zaidali/bounty-cogs).
 - [AAA3A-AAA3A](https://github.com/AAA3A-AAA3A) for the original [Dictionary cog](https://github.com/AAA3A-AAA3A/AAA3A-cogs).
 - [flaree](https://github.com/flaree) for the original [Giveaways cog](https://github.com/flaree/flare-cogs).
 


### PR DESCRIPTION
## Summary
- correct repository links in the Credits section of README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ac2feb74832c9dfd2c251cb54e07