### PR TITLE
Add Quote cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Here are some of the cogs available in this repository:
 - **Tierlists**: A cog for users to vote on items in a list, which are then ranked by tiers divided by percentiles based on up/down votes.
 - **Dictionary**: Provides dictionary and thesaurus functionalities, allowing users to look up word definitions, synonyms, and antonyms.
 - **Giveaways**: Manage and run giveaways on your Discord server. Features include customizable giveaway duration, participant requirements, and automatic winner selection.
+- **Quote**: Create an image from a replied message showing the text and the author's avatar.
 
 ## Documentation
 
@@ -41,6 +42,7 @@ Learn more about each cog in their respective guides:
 - [Tierlists](./tierlists/README.md)
 - [Dictionary](./dictionary/README.rst)
 - [Giveaways](./giveaways/README.md)
+- [Quote](./quote/README.md)
 
 ## Contact
 

--- a/quote/README.md
+++ b/quote/README.md
@@ -1,0 +1,5 @@
+# Quote
+
+Reply to a message with `!quote` and the bot will generate an image of that message in quotation marks along with the author's avatar.
+
+This cog requires the `Pillow` library which will be installed automatically when the cog is loaded.

--- a/quote/__init__.py
+++ b/quote/__init__.py
@@ -1,0 +1,6 @@
+from redbot.core.bot import Red
+
+from .quote import Quote
+
+async def setup(bot: Red):
+    await bot.add_cog(Quote(bot))

--- a/quote/info.json
+++ b/quote/info.json
@@ -1,0 +1,11 @@
+{
+    "author": ["90sCraig"],
+    "name": "Quote",
+    "install_msg": "Thank you for installing the Quote cog!",
+    "short": "Create an image quote from a replied message.",
+    "description": "Reply to a message with !quote and I'll turn it into an image with the author's avatar.",
+    "tags": ["quote", "image"],
+    "requirements": ["Pillow"],
+    "min_bot_version": "3.5.0",
+    "end_user_data_statement": "This cog does not persistently store data or metadata about users."
+}

--- a/quote/quote.py
+++ b/quote/quote.py
@@ -1,0 +1,51 @@
+import textwrap
+from io import BytesIO
+
+import discord
+from PIL import Image, ImageDraw, ImageFont
+from redbot.core import commands
+
+
+class Quote(commands.Cog):
+    """Create a stylized quote image from a replied message."""
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def quote(self, ctx: commands.Context):
+        """Quote the replied message as an image."""
+        if not ctx.message.reference or not isinstance(ctx.message.reference.resolved, discord.Message):
+            return await ctx.send("Please reply to a message to quote it.")
+
+        message: discord.Message = ctx.message.reference.resolved
+        author = message.author
+        avatar_asset = author.display_avatar.replace(size=128)
+        avatar_bytes = await avatar_asset.read()
+        avatar_img = Image.open(BytesIO(avatar_bytes)).convert("RGBA").resize((128, 128))
+
+        text = f"\u201c{message.content}\u201d"
+        font = ImageFont.load_default()
+        wrapped = textwrap.wrap(text, width=40)
+        line_height = font.getbbox("A")[3] + 4
+        text_height = line_height * len(wrapped)
+        width = 600
+        height = max(150, text_height + 40)
+        img = Image.new("RGBA", (width, height), "white")
+        draw = ImageDraw.Draw(img)
+
+        text_x = 150
+        text_y = (height - text_height) // 2
+        for line in wrapped:
+            draw.text((text_x, text_y), line, font=font, fill="black")
+            text_y += line_height
+
+        mask = avatar_img.split()[3]
+        img.paste(avatar_img, (10, (height - 128) // 2), mask)
+
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        buffer.seek(0)
+
+        file = discord.File(fp=buffer, filename="quote.png")
+        await ctx.send(file=file)


### PR DESCRIPTION
## Summary
- add Quote cog for quoting replied messages as image
- document Quote cog in repo README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6843d2a57278832cb97772b3ba3d9cfa